### PR TITLE
Fixing $PATH Inheritance Issues: Ensuring yt-dlp Works on macOS Builds

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -66,6 +66,7 @@ checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 name = "app"
 version = "0.8.2"
 dependencies = [
+ "fix-path-env",
  "serde",
  "serde_json",
  "tauri",
@@ -929,6 +930,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fix-path-env"
+version = "0.0.0"
+source = "git+https://github.com/tauri-apps/fix-path-env-rs#0e479e2804edc1a7e5f15ece2b48ee30858c2838"
+dependencies = [
+ "home",
+ "strip-ansi-escapes",
+ "thiserror",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1419,6 +1430,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "html5ever"
@@ -2987,6 +3007,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3707,6 +3736,15 @@ checksum = "d3b17ae1f6c8a2b28506cd96d412eebf83b4a0ff2cbefeeb952f2f9dfa44ba18"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "1.6.1", features = [ "os-all", "shell-execute", "dialog-open", "path-all", "notification-all", "system-tray", "shell-open"] }
 toml = "0.8.12"
+fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs" }
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem and the built-in dev server is disabled.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -40,6 +40,7 @@ fn check_cmd_in_path() -> bool {
 }
 
 fn main() {
+  let _ = fix_path_env::fix(); 
   let quit_tray = CustomMenuItem::new("quit".to_string(), "Quit");
   let toggle_tray = CustomMenuItem::new("toggle".to_string(), "Hide");
   let tray_menu = SystemTrayMenu::new()


### PR DESCRIPTION
According to the [official documentation](https://v1.tauri.app/v1/guides/building/macos/), GUI applications on macOS and Linux do not inherit the `$PATH` from shell configuration files (e.g., `.zshrc`, `.bashrc`). Since this software relies on executing `yt-dlp` in the shell environment, applying the recommended solution—using the GitHub repository [fix-path-env-rs](https://github.com/tauri-apps/fix-path-env-rs)—resolves the issue that originally caused the build to be non-functional on macOS.